### PR TITLE
Empty selector fixes

### DIFF
--- a/app/root.tsx
+++ b/app/root.tsx
@@ -67,8 +67,6 @@ export default function App() {
   const currentRouteLabel =
     navItems.find((item) => item.to === location.pathname)?.label || "Select";
 
-
-  console.log(`location.pathname: ${location.pathname}`);
   return (
     <div className="min-h-screen flex flex-col bg-background text-foreground">
       {/* Desktop Layout */}
@@ -123,7 +121,7 @@ export default function App() {
         <nav className="p-4 sticky top-0 z-10 bg-background">
           <Select
             value={location.pathname}
-            defaultValue={location.pathname}
+            defaultValue={currentRouteLabel}
             onValueChange={(value) => navigate(value)}
           >
             <SelectTrigger className="w-full">

--- a/app/root.tsx
+++ b/app/root.tsx
@@ -67,6 +67,8 @@ export default function App() {
   const currentRouteLabel =
     navItems.find((item) => item.to === location.pathname)?.label || "Select";
 
+
+  console.log(`location.pathname: ${location.pathname}`);
   return (
     <div className="min-h-screen flex flex-col bg-background text-foreground">
       {/* Desktop Layout */}
@@ -121,6 +123,7 @@ export default function App() {
         <nav className="p-4 sticky top-0 z-10 bg-background">
           <Select
             value={location.pathname}
+            defaultValue={location.pathname}
             onValueChange={(value) => navigate(value)}
           >
             <SelectTrigger className="w-full">

--- a/app/root.tsx
+++ b/app/root.tsx
@@ -82,6 +82,7 @@ export default function App() {
                 <li key={item.to}>
                   <NavLink
                     to={item.to}
+                    end
                     className={({ isActive }) =>
                       cn(
                         "block w-full",


### PR DESCRIPTION
Fixes a bug where the nav select element on mobile would be empty in production. This was done by making sure there was a defaultValue specified for the `Select` element.